### PR TITLE
Enhance PR Size Labelling

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -21,7 +21,8 @@ jobs:
     name: Label Pull Request
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5.0.0
+      - name: Label Pull Request
+        uses: actions/labeler@v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/other-configurations/labeller.yml
@@ -31,3 +32,13 @@ jobs:
         uses: pascalgn/size-label-action@v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          with:
+          sizes: >
+            {
+              "0": "XS",
+              "20": "S",
+              "50": "M",
+              "200": "L",
+              "500": "XL",
+              "1000": "XXL"
+            }


### PR DESCRIPTION
# Pull Request

## Description

This change enhances the pull request labelling process in the GitHub Actions workflow. The following modifications have been made:

1. Added a name "Label Pull Request" to the labeller action for improved readability.

2. Expanded the size-label-action configuration by adding a `with` block that defines custom size thresholds for pull requests. The new size labels are:

   - XS: 0-19 lines
   - S: 20-49 lines
   - M: 50-199 lines
   - L: 200-499 lines
   - XL: 500-999 lines
   - XXL: 1000+ lines

These changes will provide more granular and informative labels for pull requests based on their size, helping to streamline the review process.