### PR TITLE
Update Repository Labels

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -2,7 +2,17 @@
 documentation:
   - any:
       - changed-files:
-          - any-glob-to-any-file: ["README.md", "docs/**"]
+          - any-glob-to-any-file: ["README.md", "*.md", "docs/**"]
+markdown:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              [
+                "docs/*.md",
+                "*.md",
+                "LICENSE",
+                ".github/pull_request_template.md",
+              ]
 dependencies:
   - any:
       - changed-files:
@@ -19,9 +29,8 @@ shell:
 github_actions:
   - any:
       - changed-files:
-          - any-glob-to-any-file:
-              [".github/workflows/*", ".github/workflows/**/*"]
-git-hooks:
+          - any-glob-to-any-file: [".github/workflows/*", ".github/actions/*"]
+git_hooks:
   - any:
       - changed-files:
           - any-glob-to-any-file: ["githooks/**"]

--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -39,9 +39,12 @@
 - color: 00ff44
   name: shell
   description: Pull requests that update Shell code
+- color: 1900ff
+  name: markdown
+  description: Pull requests that update Markdown documentation
 # Components
 - color: ff0073
-  name: git-hooks
+  name: git_hooks
   description: Pull requests that update git hooks
 - color: ebff36
   name: radar


### PR DESCRIPTION
## Description

This pull request includes updates to the `.github/other-configurations/labeller.yml` and `.github/other-configurations/labels.yml` files to improve the labeling of pull requests. The most important changes include adding a new label for markdown files, updating the glob patterns for file changes, and correcting the naming convention for existing labels.

Labeling improvements:

* [`.github/other-configurations/labeller.yml`](diffhunk://#diff-b490f987d9b055ce6e06e37d13763d61f6e0d5ee349b390bbb910f8d88ff36b9L5-R15): Added a new `markdown` label to handle changes in markdown files and updated the glob patterns to include more markdown files.
* [`.github/other-configurations/labels.yml`](diffhunk://#diff-c1b32711b0f3da3f5c7007cfaa4d9e94ae5430fea1f4e1256f6210bc6988553dR42-R47): Added a new `markdown` label with a description for pull requests that update markdown documentation.

Configuration updates:

* [`.github/other-configurations/labeller.yml`](diffhunk://#diff-b490f987d9b055ce6e06e37d13763d61f6e0d5ee349b390bbb910f8d88ff36b9L22-R33): Updated the `github_actions` glob pattern to include `.github/actions/*` and corrected the naming convention for the `git_hooks` label.
* [`.github/other-configurations/labels.yml`](diffhunk://#diff-c1b32711b0f3da3f5c7007cfaa4d9e94ae5430fea1f4e1256f6210bc6988553dR42-R47): Corrected the naming convention for the `git_hooks` label to match the changes in the labeller configuration.

Fixes #79 