### PR TITLE
Fix Zizmor Warnings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,9 +6,7 @@ on:
       - main
 
 permissions:
-  contents: write
-  pages: write
-  id-token: write
+  contents: read
 
 jobs:
   deploy-github-pages:
@@ -16,7 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     timeout-minutes: 60
     steps:
       - name: Checkout

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -13,13 +13,14 @@ on:
         ready_for_review,
       ]
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
   labeller:
     name: Label Pull Request
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Label Pull Request
         uses: actions/labeler@v5.0.0

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -9,16 +9,18 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   configure-labels:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: micnncim/action-label-syncer@v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the permissions settings in several GitHub Actions workflow files. The modifications aim to refine the permissions granted to various jobs within these workflows.

Changes to permissions settings:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L9-R20): Updated the `permissions` section to set `contents` to `read` globally and moved specific permissions for the `deploy-github-pages` job.
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL16-R23): Replaced the global `permissions` section with an empty object and added specific permissions for the `labeller` job.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L12-R23): Added specific permissions for the `configure-labels` job and included the `persist-credentials` option in the `Checkout` step.

Fixes #96 
