### PR TITLE
Add Dark Mode

### DIFF
--- a/github-pages/dark-mode.css
+++ b/github-pages/dark-mode.css
@@ -1,0 +1,67 @@
+body.dark-mode {
+  background-color: #121212;
+  color: #e0e0e0;
+}
+
+body.dark-mode h3 {
+  color: #bb86fc;
+}
+
+body.dark-mode table {
+  border-color: #333;
+}
+
+body.dark-mode td {
+  border-color: #333;
+}
+
+#theme-toggle {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  border: 1px solid #666;
+  background: #fff;
+  cursor: pointer;
+}
+
+body.dark-mode #theme-toggle {
+  background: #333;
+  color: #fff;
+  border-color: #888;
+}
+
+body.dark-mode #radar text,
+body.dark-mode #radar tspan {
+  fill: #ffffff !important;
+  color: #ffffff !important;
+}
+
+body.dark-mode .quadrant-group text {
+  fill: #ffffff !important;
+}
+
+body.dark-mode .legend text {
+  fill: #ffffff !important;
+}
+
+body.dark-mode .blip-link text {
+  fill: #ffffff !important;
+}
+
+body.dark-mode .line-text {
+  fill: #ffffff !important;
+}
+
+body.dark-mode #radar text {
+  fill: #ffffff !important;
+}
+
+body.dark-mode #radar .legend {
+  color: #ffffff;
+}
+
+body.dark-mode a {
+  color: #bb86fc;
+}

--- a/github-pages/dark-mode.css
+++ b/github-pages/dark-mode.css
@@ -33,5 +33,5 @@ body.dark-mode #theme-toggle {
 }
 
 body.dark-mode text {
-  fill: #ffffff;
+  fill: #fff;
 }

--- a/github-pages/dark-mode.css
+++ b/github-pages/dark-mode.css
@@ -32,36 +32,6 @@ body.dark-mode #theme-toggle {
   border-color: #888;
 }
 
-body.dark-mode #radar text,
-body.dark-mode #radar tspan {
-  fill: #ffffff !important;
-  color: #ffffff !important;
-}
-
-body.dark-mode .quadrant-group text {
-  fill: #ffffff !important;
-}
-
-body.dark-mode .legend text {
-  fill: #ffffff !important;
-}
-
-body.dark-mode .blip-link text {
-  fill: #ffffff !important;
-}
-
-body.dark-mode .line-text {
-  fill: #ffffff !important;
-}
-
-body.dark-mode #radar text {
-  fill: #ffffff !important;
-}
-
-body.dark-mode #radar .legend {
-  color: #ffffff;
-}
-
-body.dark-mode a {
-  color: #bb86fc;
+body.dark-mode text {
+  fill: #ffffff;
 }

--- a/github-pages/index.html
+++ b/github-pages/index.html
@@ -26,18 +26,19 @@
 
     <script>
       // Theme management
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
-      const storedTheme = localStorage.getItem('theme');
-      const isDarkMode = storedTheme === 'dark' || (!storedTheme && prefersDark.matches);
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
+      const storedTheme = localStorage.getItem("theme");
+      const isDarkMode =
+        storedTheme === "dark" || (!storedTheme && prefersDark.matches);
 
       function setTheme(isDark) {
-        document.body.classList.toggle('dark-mode', isDark);
-        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        document.body.classList.toggle("dark-mode", isDark);
+        localStorage.setItem("theme", isDark ? "dark" : "light");
         initializeRadar(isDark);
       }
 
-      document.getElementById('theme-toggle').addEventListener('click', () => {
-        setTheme(!document.body.classList.contains('dark-mode'));
+      document.getElementById("theme-toggle").addEventListener("click", () => {
+        setTheme(!document.body.classList.contains("dark-mode"));
       });
 
       // Radar initialization
@@ -47,17 +48,19 @@
             return response.json();
           })
           .then(function (data) {
-            const colors = isDark ? {
-              background: "#121212",
-              grid: "#333",
-              inactive: "#666"
-            } : {
-              background: "#fff",
-              grid: "#bbb",
-              inactive: "#ddd"
-            };
+            const colors = isDark
+              ? {
+                  background: "#121212",
+                  grid: "#333",
+                  inactive: "#666",
+                }
+              : {
+                  background: "#fff",
+                  grid: "#bbb",
+                  inactive: "#ddd",
+                };
 
-            document.getElementById('radar').innerHTML = '';
+            document.getElementById("radar").innerHTML = "";
             radar_visualization({
               repo_url: "https://github.com/JackPlowman/tech-radar",
               title: "Jack Plowman's Tech Radar",

--- a/github-pages/index.html
+++ b/github-pages/index.html
@@ -17,52 +17,83 @@
     <script src="https://zalando.github.io/tech-radar/release/radar-0.8.js"></script>
 
     <link rel="stylesheet" href="radar.css" />
+    <link rel="stylesheet" href="dark-mode.css" />
   </head>
 
-  <svg id="radar"></svg>
-
   <body>
+    <button id="theme-toggle">Toggle Theme</button>
+    <svg id="radar"></svg>
+
     <script>
-      fetch("./config.json")
-        .then(function (response) {
-          return response.json();
-        })
-        .then(function (data) {
-          radar_visualization({
-            repo_url: "https://github.com/JackPlowman/tech-radar",
-            title: "Jack Plowman's Tech Radar",
-            date: data.date,
-            svg_id: "radar",
-            width: 1450,
-            height: 1000,
-            scale: 1.0,
-            colors: {
+      // Theme management
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+      const storedTheme = localStorage.getItem('theme');
+      const isDarkMode = storedTheme === 'dark' || (!storedTheme && prefersDark.matches);
+
+      function setTheme(isDark) {
+        document.body.classList.toggle('dark-mode', isDark);
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        initializeRadar(isDark);
+      }
+
+      document.getElementById('theme-toggle').addEventListener('click', () => {
+        setTheme(!document.body.classList.contains('dark-mode'));
+      });
+
+      // Radar initialization
+      function initializeRadar(isDark) {
+        fetch("./config.json")
+          .then(function (response) {
+            return response.json();
+          })
+          .then(function (data) {
+            const colors = isDark ? {
+              background: "#121212",
+              grid: "#333",
+              inactive: "#666"
+            } : {
               background: "#fff",
               grid: "#bbb",
-              inactive: "#ddd",
-            },
-            font_family: "Arial, Helvetica",
-            quadrants: [
-              { name: "Tools:" },
-              { name: "Platforms & Cloud Services:" },
-              { name: "Languages & Frameworks:" },
-              { name: "Techniques & Methodologies:" },
-            ],
-            rings: [
-              { name: "EXPERIENCED", color: "#5ba300" },
-              { name: "TRIAL", color: "#009eb0" },
-              { name: "WATCH", color: "#c7ba00" },
-              { name: "MAINTAIN", color: "#e09b96" },
-            ],
-            print_layout: true,
-            links_in_new_tabs: true,
-            entries: data.entries,
+              inactive: "#ddd"
+            };
+
+            document.getElementById('radar').innerHTML = '';
+            radar_visualization({
+              repo_url: "https://github.com/JackPlowman/tech-radar",
+              title: "Jack Plowman's Tech Radar",
+              date: data.date,
+              svg_id: "radar",
+              width: 1450,
+              height: 1000,
+              scale: 1.0,
+              colors: colors,
+              font_family: "Arial, Helvetica",
+              quadrants: [
+                { name: "Tools:" },
+                { name: "Platforms & Cloud Services:" },
+                { name: "Languages & Frameworks:" },
+                { name: "Techniques & Methodologies:" },
+              ],
+              rings: [
+                { name: "EXPERIENCED", color: "#5ba300" },
+                { name: "TRIAL", color: "#009eb0" },
+                { name: "WATCH", color: "#c7ba00" },
+                { name: "MAINTAIN", color: "#e09b96" },
+              ],
+              print_layout: true,
+              links_in_new_tabs: true,
+              entries: data.entries,
+            });
+          })
+          .catch(function (err) {
+            console.log("Error loading config.json", err);
           });
-        })
-        .catch(function (err) {
-          console.log("Error loading config.json", err);
-        });
+      }
+
+      // Initial setup
+      setTheme(isDarkMode);
     </script>
+
     <table>
       <tbody>
         <tr>


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a dark mode feature for the GitHub Pages site, enhancing the user experience by allowing users to toggle between light and dark themes. The main changes include the addition of a dark mode stylesheet, JavaScript for theme management, and the initialization of the radar visualization with appropriate colors based on the selected theme.

Dark mode implementation:

* [`github-pages/dark-mode.css`](diffhunk://#diff-7aaa063b7dca8c647dd39fcd2bd69834a4f239ca2918fe611983c917e91cd86bR1-R37): Added styles for dark mode, including background color, text color, and table border color adjustments.

Theme management and initialization:

* `github-pages/index.html`: 
  * Included the new dark mode stylesheet in the HTML header.
  * Added a theme toggle button and JavaScript functions to manage theme switching and store the user's preference in local storage.
  * Modified the radar initialization to use different colors based on the selected theme. [[1]](diffhunk://#diff-ae58aaeb8116bb7f047a03fcc6032fd7c0d9908041a6463eece65ae3f1413e7eL39-R72) [[2]](diffhunk://#diff-ae58aaeb8116bb7f047a03fcc6032fd7c0d9908041a6463eece65ae3f1413e7eR94-R99)

Fixes #98 
