### PR TITLE
Disable Deployment Concurrency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   deploy-github-pages:
     name: Deploy to GitHub Pages


### PR DESCRIPTION
# Pull Request

## Description


This pull request includes a change to the `.github/workflows/deploy.yml` file to improve the deployment workflow by adding concurrency control.

Improvements to deployment workflow:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R11-R14): Added `concurrency` configuration to ensure that only one deployment job runs at a time and cancels any in-progress job if a new one is triggered.

Fixes #120
