### PR TITLE
Merge pre-commit Git Hooks

### DIFF
--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e +x
 
-gitleaks detect --source .
+echo "Running pre-commit hooks"
+gitleaks detect --source . -q
 just prettier-format
 just format-check

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e +x
 
-echo "Running pre-commit hooks"
+echo "Running pre-commit hooks checks"
 gitleaks detect --source . -q
 just prettier-format
 just format-check
+echo "pre-commit hooks checks passed"

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,13 +1,6 @@
 #!/bin/bash
 set -e +x
 
-# shellcheck disable=SC2045,SC2028,SC2086,SC2206,SC2128
-for script in $(ls -1 githooks/pre-commit-scripts/*.sh 2>/dev/null); do
-  ts=$SECONDS
-  echo "Running githook: $script \n"
-  bash $script
-  te=($SECONDS - $ts)
-  echo "Script Took (${te}s)\n"
-done
-
-printf "pre-commit complete \n\n"
+gitleaks detect --source .
+just prettier-format
+just format-check

--- a/githooks/pre-commit-scripts/gitleaks.sh
+++ b/githooks/pre-commit-scripts/gitleaks.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e +x
-
-gitleaks detect --source .

--- a/githooks/pre-commit-scripts/justfile.sh
+++ b/githooks/pre-commit-scripts/justfile.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e +x
-
-just format

--- a/githooks/pre-commit-scripts/prettier.sh
+++ b/githooks/pre-commit-scripts/prettier.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e +x
-
-just prettier-format


### PR DESCRIPTION
# Pull Request

## Description

This pull request simplifies the pre-commit hook process by consolidating the scripts into a single command and removing redundant individual script files. The most important changes include updating the `githooks/pre-commit` file and removing the separate script files for `gitleaks`, `justfile`, and `prettier`.

Simplification of pre-commit hooks:

* [`githooks/pre-commit`](diffhunk://#diff-d5fe9d324948511c959e14d0aa311bb057ce7236626bb86fa51351dc26845a4dL4-R8): Updated the pre-commit hook to run `gitleaks`, `prettier-format`, and `format-check` commands directly, removing the loop that executed individual scripts.

Removal of redundant scripts:

* [`githooks/pre-commit-scripts/gitleaks.sh`](diffhunk://#diff-b488692093f21df73d5c8d67f3a6df3273b7199a34ca84e9c9e1a115b20df271L1-L4): Removed the individual script for running `gitleaks`.
* [`githooks/pre-commit-scripts/justfile.sh`](diffhunk://#diff-fcd01eccc95d37bac6ab073a69ec60e574b754774360a13f31e1a39466668fc9L1-L4): Removed the individual script for running `just format`.
* [`githooks/pre-commit-scripts/prettier.sh`](diffhunk://#diff-1e2ab1eef74462625d345d9811c6cd8e51996878583f4a9878ad8d62ec7d014dL1-L4): Removed the individual script for running `prettier-format`.