### PR TITLE
Hide pre-commit logs

### DIFF
--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -2,7 +2,7 @@
 set -e +x
 
 echo "Running pre-commit hooks checks"
-gitleaks detect --source . -q
-just prettier-format
-just format-check
+gitleaks detect --source . > /dev/null
+just prettier-format > /dev/null
+just format-check > /dev/null
 echo "pre-commit hooks checks passed"

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -3,6 +3,6 @@ set -e +x
 
 echo "Running pre-commit hooks checks"
 gitleaks detect --source . > /dev/null
-just prettier-format > /dev/null
-just format-check > /dev/null
+just -q prettier-format
+just -q format-check
 echo "pre-commit hooks checks passed"

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -2,7 +2,7 @@
 set -e +x
 
 echo "Running pre-commit hooks checks"
-gitleaks detect --source . > /dev/null
+gitleaks detect --source . >/dev/null
 just -q prettier-format
 just -q format-check
 echo "pre-commit hooks checks passed"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes improvements to the `githooks/pre-commit` file to enhance the pre-commit hooks checks. The most important changes include modifying the commands to suppress output and errors.

Changes to pre-commit hooks:

* [`githooks/pre-commit`](diffhunk://#diff-d5fe9d324948511c959e14d0aa311bb057ce7236626bb86fa51351dc26845a4dL5-R7): Updated `gitleaks detect` to redirect output to `/dev/null` and added the `-q` flag to `just` commands to suppress output.
