### PR TITLE
Migrate Git Hooks to Lefthook

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -2,9 +2,11 @@
 # Prettier
 # ------------------------------------------------------------------------------
 
+# Check all files with prettier
 prettier-check:
     prettier . --check
 
+# Format all files with prettier
 prettier-format:
     prettier . --check --write
 
@@ -12,18 +14,37 @@ prettier-format:
 # Justfile
 # ------------------------------------------------------------------------------
 
+# Format Justfile
 format:
     just --fmt --unstable
 
+# Check Justfile formatting
 format-check:
     just --fmt --check --unstable
 
 # ------------------------------------------------------------------------------
-# gitleaks
+# Gitleaks
 # ------------------------------------------------------------------------------
 
+# Run gitleaks detection
 gitleaks-detect:
-    gitleaks detect --source . > /dev/null
+    gitleaks detect --source .
+
+# ------------------------------------------------------------------------------
+# Lefthook
+# ------------------------------------------------------------------------------
+
+# Validate lefthook config
+lefthook-validate:
+    lefthook validate
+
+# ------------------------------------------------------------------------------
+# Zizmor
+# ------------------------------------------------------------------------------
+
+# Run zizmor checking
+zizmor-check:
+    zizmor .
 
 # ------------------------------------------------------------------------------
 # Git Hooks
@@ -31,6 +52,4 @@ gitleaks-detect:
 
 # Install pre commit hook to run on all commits
 install-git-hooks:
-    cp -f githooks/pre-commit .git/hooks/pre-commit
-    cp -f githooks/post-commit .git/hooks/post-commit
-    chmod ug+x .git/hooks/*
+    lefthook install -f

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,20 @@
+# https://github.com/evilmartians/lefthook
+min_version: 1.11.2
+colors: true
+
+output:
+  - summary
+
+pre-commit:
+  parallel: true
+  commands:
+    Git Leaks Detection:
+      run: just gitleaks-detect
+    Prettier Checks:
+      run: just prettier-check
+    Justfile Format Checks:
+      run: just format-check
+    Lefthook Validate:
+      run: just lefthook-validate
+    Zizmor Checks:
+      run: just zizmor-check


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces several new commands to the `Justfile` for code formatting, checking, and validation, and it also integrates these commands into the `lefthook` pre-commit hooks configuration.

New commands in `Justfile`:

* Added commands for checking and formatting files with Prettier.
* Added commands for formatting and checking the `Justfile` itself.
* Added a command to run Gitleaks detection without redirecting output to `/dev/null`.
* Added commands for validating Lefthook configuration and running Zizmor checks.
* Updated the `install-git-hooks` command to use Lefthook for installing git hooks.

Integration with Lefthook:

* Created a `lefthook.yml` configuration file to define pre-commit hooks that run the new `Justfile` commands in parallel.