### PR TITLE
Remove CodeQL Configuration

### DIFF
--- a/.github/other-configurations/codeql-config.yml
+++ b/.github/other-configurations/codeql-config.yml
@@ -1,3 +1,0 @@
-query-filters:
-  - exclude:
-      id: actions/unpinned-tag

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -139,6 +139,5 @@ jobs:
         with:
           languages: actions
           queries: security-and-quality
-          config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.28.12


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes adjustments to the CodeQL configuration and workflow by removing a custom configuration file and its associated references. These changes simplify the setup and ensure the default CodeQL behavior is used.

### CodeQL Configuration Updates:

* [`.github/other-configurations/codeql-config.yml`](diffhunk://#diff-687a0af9316072cbdab79cdb046aac181231f8b5f3b5502bc796a9d949ce65beL1-L3): Removed the custom CodeQL query filter that excluded the `actions/unpinned-tag` query.

### Workflow Updates:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L142): Removed the reference to the deleted CodeQL configuration file in the `codeql-action/init` step, allowing the workflow to use the default configuration.