### PR TITLE
Remove Pinact Configuration

### DIFF
--- a/.github/other-configurations/pinact.yml
+++ b/.github/other-configurations/pinact.yml
@@ -1,9 +1,0 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
-# pinact - https://github.com/suzuki-shunsuke/pinact
-version: 3
-
-ignore_actions:
-  - name: actions/.*
-    ref: .*
-  - name: github/codeql-action/.*
-    ref: .*

--- a/Justfile
+++ b/Justfile
@@ -52,15 +52,15 @@ zizmor-check:
 
 # Run pinact
 pinact-run:
-    pinact run -c .github/other-configurations/pinact.yml
+    pinact run
 
 # Run pinact checking
 pinact-check:
-    pinact run -c .github/other-configurations/pinact.yml --verify --check
+    pinact run --verify --check
 
 # Run pinact update
 pinact-update:
-    pinact run -c .github/other-configurations/pinact.yml --update
+    pinact run --update
 
 # ------------------------------------------------------------------------------
 # Git Hooks


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes the use of a custom configuration file for the `pinact` tool and updates related commands in the `Justfile` to use the default configuration. The most important changes are as follows:

### Removal of custom configuration:

* Deleted the `.github/other-configurations/pinact.yml` file, which contained a custom configuration for the `pinact` tool.

### Updates to `pinact` commands:

* Modified `pinact` commands in the `Justfile` (`pinact-run`, `pinact-check`, and `pinact-update`) to no longer reference the deleted custom configuration file, relying instead on the default configuration.