### PR TITLE
 Change Jobs to Common Pull Request Tasks

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -2,59 +2,16 @@ name: "Pull Request Tasks"
 
 on:
   pull_request:
-    types:
-      [
-        opened,
-        edited,
-        unlocked,
-        labeled,
-        synchronize,
-        reopened,
-        ready_for_review,
-      ]
+    types: [opened, edited, synchronize]
 
-permissions: {}
+permissions:
+  pull-requests: read
 
 jobs:
-  labeller:
-    name: Label Pull Request
-    runs-on: ubuntu-latest
+  common-pull-request-tasks:
+    name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    steps:
-      - name: Label Pull Request
-        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          configuration-path: .github/other-configurations/labeller.yml
-          sync-labels: true
-      - name: Add Size Labels
-        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        with:
-          sizes: >
-            {
-              "0": "XS",
-              "40": "S",
-              "100": "M",
-              "200": "L",
-              "800": "XL",
-              "2000": "XXL"
-            }
-
-  dependency-review:
-    name: Dependency Review
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Dependency Review
-        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
-        with:
-          comment-summary-in-pr: on-failure
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@14445779094fde883fdb9f65946fcae6c25f46c0 # v2025.05.14.01
+    secrets:
+      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request simplifies and consolidates the workflow configuration for pull request tasks by reducing event types, removing redundant jobs, and reusing a shared workflow. The changes improve maintainability and reduce duplication in the CI/CD pipeline.

### Workflow simplification and consolidation:

* Reduced the `pull_request` event types to only `opened`, `edited`, and `synchronize`, removing less commonly used triggers like `unlocked`, `labeled`, and `ready_for_review`. (`[.github/workflows/pull-request-tasks.ymlL5-R17](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL5-R17)`)
* Removed individual jobs for labeling pull requests and dependency review, along with their associated steps and configurations, in favor of using a shared reusable workflow. (`[.github/workflows/pull-request-tasks.ymlL5-R17](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL5-R17)`)
* Replaced the `labeller` and `dependency-review` jobs with a single `common-pull-request-tasks` job, which references the reusable workflow `common-pull-request-tasks.yml` from an external repository. (`[.github/workflows/pull-request-tasks.ymlL5-R17](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL5-R17)`)