### PR TITLE
Add Link Tests to Deployment Workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,3 +68,21 @@ jobs:
         run: just tests::run-ci "$BROWSER"
         env:
           BROWSER: ${{ matrix.browser }}
+
+  link-tests:
+    name: Link Tests
+    runs-on: ubuntu-latest
+    needs: deploy-github-pages
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Run Link Tests
+        uses: JustinBeckwith/linkinator-action@3d5ba091319fa7b0ac14703761eebb7d100e6f6d # v1.11.0
+        with:
+          paths: https://jackplowman.github.io/tech-radar/
+          recurse: true
+          timeout: 1000
+          markdown: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new job to the GitHub Actions workflow for running link tests on the deployed GitHub Pages site. The addition aims to ensure the integrity of links on the website after deployment.

Enhancements to CI/CD workflow:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R71-R88): Added a new job named `link-tests` that runs on `ubuntu-latest`, depends on the `deploy-github-pages` job, and uses the `linkinator-action` to validate links on the deployed site. This includes steps for checking out the repository and running the link tests with specific configurations, such as recursion and timeout settings.
