### PR TITLE
Add links part 1

### DIFF
--- a/github-pages/config.json
+++ b/github-pages/config.json
@@ -6,63 +6,80 @@
       "ring": 0,
       "label": "Python",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.python.org/"
     },
     {
       "quadrant": 2,
       "ring": 0,
       "label": "AWS Lambda Powertools (Python)",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://docs.powertools.aws.dev/lambda/python/latest/"
     },
     {
       "quadrant": 2,
       "ring": 1,
       "label": "OpenAPI Specifications",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://swagger.io/specification/"
     },
     {
       "quadrant": 2,
       "ring": 0,
       "label": "REST",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://restfulapi.net/"
     },
     {
       "quadrant": 2,
       "ring": 1,
       "label": "Go",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://go.dev/"
     },
     {
       "quadrant": 2,
       "ring": 1,
       "label": "Rust",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.rust-lang.org/"
     },
     {
       "quadrant": 2,
       "ring": 1,
       "label": "TypeScript",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.typescriptlang.org/"
     },
     {
       "quadrant": 2,
       "ring": 3,
       "label": "JavaScript",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://en.wikipedia.org/wiki/JavaScript"
     },
     {
       "quadrant": 2,
       "ring": 0,
-      "label": "Terraform/OpenTofu",
+      "label": "Terraform",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://developer.hashicorp.com/terraform"
+    },
+    {
+      "quadrant": 2,
+      "ring": 0,
+      "label": "OpenTofu",
+      "active": true,
+      "moved": 0,
+      "link": "https://opentofu.org/"
     },
     {
       "quadrant": 2,


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `github-pages/config.json` file to enhance the metadata for various technologies and make the configuration more precise. The changes include adding links to official documentation or websites for each technology and splitting "Terraform/OpenTofu" into separate entries for "Terraform" and "OpenTofu."

Enhancements to metadata:

* Added `link` fields with URLs to official documentation or websites for the following technologies: Python, AWS Lambda Powertools (Python), OpenAPI Specifications, REST, Go, Rust, TypeScript, and JavaScript.

Improvements to configuration structure:

* Split the "Terraform/OpenTofu" entry into two separate entries: one for "Terraform" with its own link and another for "OpenTofu" with its respective link.