### PR TITLE
Add links part 3

### DIFF
--- a/github-pages/config.json
+++ b/github-pages/config.json
@@ -150,84 +150,96 @@
       "ring": 0,
       "label": "AWS S3",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://aws.amazon.com/s3/"
     },
     {
       "quadrant": 1,
       "ring": 0,
       "label": "AWS Secrets Manager",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://aws.amazon.com/secrets-manager/"
     },
     {
       "quadrant": 1,
       "ring": 0,
       "label": "AWS Parameter Store",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://aws.amazon.com/systems-manager/"
     },
     {
       "quadrant": 1,
       "ring": 0,
       "label": "AWS Lambda",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://aws.amazon.com/lambda/"
     },
     {
       "quadrant": 1,
       "ring": 0,
       "label": "AWS Elastic Container Registry",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://aws.amazon.com/ecr/"
     },
     {
       "quadrant": 1,
       "ring": 0,
       "label": "AWS Step Functions",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://aws.amazon.com/step-functions/"
     },
     {
       "quadrant": 1,
       "ring": 0,
       "label": "AWS DynamoDB",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://aws.amazon.com/dynamodb/"
     },
     {
       "quadrant": 1,
       "ring": 0,
       "label": "AWS Aurora",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://aws.amazon.com/rds/aurora/"
     },
     {
       "quadrant": 1,
       "ring": 0,
       "label": "AWS Relational Database Service (RDS)",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://aws.amazon.com/rds/"
     },
     {
       "quadrant": 1,
       "ring": 0,
       "label": "GitHub",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://github.com/"
     },
     {
       "quadrant": 1,
       "ring": 0,
       "label": "GitHub Actions",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://github.com/features/actions"
     },
     {
       "quadrant": 1,
       "ring": 0,
       "label": "GitHub Pages",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://pages.github.com/"
     },
     {
       "quadrant": 1,

--- a/github-pages/config.json
+++ b/github-pages/config.json
@@ -23,7 +23,7 @@
       "label": "OpenAPI Specifications",
       "active": true,
       "moved": 0,
-      "link": "https://swagger.io/specification/"
+      "link": "https://www.openapis.org/"
     },
     {
       "quadrant": 2,
@@ -86,56 +86,64 @@
       "ring": 0,
       "label": "Bash",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.gnu.org/software/bash/"
     },
     {
       "quadrant": 2,
       "ring": 0,
       "label": "GNU Make",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.gnu.org/software/make/"
     },
     {
       "quadrant": 2,
       "ring": 0,
       "label": "Just (Command Runner)",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://github.com/casey/just"
     },
     {
       "quadrant": 2,
       "ring": 1,
       "label": "React",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://react.dev/"
     },
     {
       "quadrant": 2,
       "ring": 2,
       "label": "Astro",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://astro.build/"
     },
     {
       "quadrant": 2,
       "ring": 2,
       "label": "Tanstack",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://tanstack.com/"
     },
     {
       "quadrant": 2,
       "ring": 2,
-      "label": "Vite/Rolldown",
+      "label": "Vite",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://vitejs.dev/"
     },
     {
       "quadrant": 2,
       "ring": 1,
       "label": "NextJS",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://nextjs.org/"
     },
     {
       "quadrant": 1,


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `github-pages/config.json` file to include external links for various technologies and tools listed in the configuration. It also updates the label for one entry ("Vite/Rolldown" to "Vite") for consistency.

### Updates to external links:

* Replaced the link for "OpenAPI Specifications" with the updated official website (`https://www.openapis.org/`).
* Added external links for several tools and technologies, including "Bash," "GNU Make," "Just (Command Runner)," "React," "Astro," "Tanstack," "Vite," "NextJS," and various AWS services such as "AWS S3," "AWS Lambda," and "AWS DynamoDB," among others.

### Label update:

* Updated the label "Vite/Rolldown" to "Vite" for clarity and alignment with the official tool name.