### PR TITLE
Add config schema

### DIFF
--- a/tests/config.schema.json
+++ b/tests/config.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/JackPlowman/tech-radar/main/github-pages/config.schema.json",
+  "title": "Tech Radar Configuration",
+  "description": "JSON Schema for Tech Radar configuration file that defines technologies, tools, techniques, and platforms plotted on a radar visualization",
+  "type": "object",
+  "properties": {
+    "date": {
+      "type": "string",
+      "description": "The date/version of this tech radar snapshot",
+      "pattern": "^\\d{4}\\.\\d{2}$",
+      "examples": ["2025.07", "2024.12"]
+    },
+    "entries": {
+      "type": "array",
+      "description": "Array of technology entries to be plotted on the radar",
+      "items": {
+        "$ref": "#/$defs/radarEntry"
+      },
+      "minItems": 1
+    }
+  },
+  "required": ["date", "entries"],
+  "additionalProperties": false,
+  "$defs": {
+    "radarEntry": {
+      "type": "object",
+      "description": "A single technology entry on the tech radar",
+      "properties": {
+        "quadrant": {
+          "type": "integer",
+          "description": "The quadrant where this entry appears (0: Tools, 1: Platforms, 2: Languages & Frameworks, 3: Techniques)",
+          "minimum": 0,
+          "maximum": 3
+        },
+        "ring": {
+          "type": "integer",
+          "description": "The ring/level of adoption (0: Adopt, 1: Trial, 2: Assess, 3: Hold)",
+          "minimum": 0,
+          "maximum": 3
+        },
+        "label": {
+          "type": "string",
+          "description": "The name/label of the technology",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "active": {
+          "type": "boolean",
+          "description": "Whether this entry is currently active/visible on the radar"
+        },
+        "moved": {
+          "type": "integer",
+          "description": "Movement indicator (-1: moved out, 0: no change, 1: moved in)",
+          "minimum": -1,
+          "maximum": 1
+        },
+        "link": {
+          "type": "string",
+          "description": "Optional URL link to more information about this technology",
+          "format": "uri",
+          "examples": ["https://www.python.org/", "https://go.dev/"]
+        }
+      },
+      "required": ["quadrant", "ring", "label", "active", "moved"],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a JSON Schema definition for validating Tech Radar configuration files. The schema ensures that the configuration adheres to a specific structure and includes required fields for defining technologies, tools, techniques, and platforms plotted on a radar visualization.

### JSON Schema for Tech Radar Configuration:

* **Schema Metadata**:
  - Added `$schema` and `$id` fields to define the schema's version and unique identifier. (`[tests/config.schema.jsonR1-R69](diffhunk://#diff-274a00db93cc41e3ec41836449f37fc00a50c0939b9e1d86ce1264bf3894038aR1-R69)`)
  - Included `title` and `description` fields to describe the purpose of the schema. (`[tests/config.schema.jsonR1-R69](diffhunk://#diff-274a00db93cc41e3ec41836449f37fc00a50c0939b9e1d86ce1264bf3894038aR1-R69)`)

* **Top-Level Properties**:
  - Defined `date` as a required string field with a specific pattern (e.g., `YYYY.MM`) to represent the snapshot's date/version. (`[tests/config.schema.jsonR1-R69](diffhunk://#diff-274a00db93cc41e3ec41836449f37fc00a50c0939b9e1d86ce1264bf3894038aR1-R69)`)
  - Added `entries` as a required array field containing technology entries, each validated against a `radarEntry` definition. (`[tests/config.schema.jsonR1-R69](diffhunk://#diff-274a00db93cc41e3ec41836449f37fc00a50c0939b9e1d86ce1264bf3894038aR1-R69)`)

* **Radar Entry Definition**:
  - Created a `$defs.radarEntry` object to standardize individual technology entries.
  - Defined properties such as `quadrant`, `ring`, `label`, `active`, `moved`, and an optional `link` with specific types, constraints, and descriptions. (`[tests/config.schema.jsonR1-R69](diffhunk://#diff-274a00db93cc41e3ec41836449f37fc00a50c0939b9e1d86ce1264bf3894038aR1-R69)`)
  - Ensured `quadrant` and `ring` values are integers within defined ranges, and `label` has length