### PR TITLE
Add links part 4

### DIFF
--- a/github-pages/config.json
+++ b/github-pages/config.json
@@ -246,56 +246,64 @@
       "ring": 1,
       "label": "AWS Kinesis",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://aws.amazon.com/kinesis/"
     },
     {
       "quadrant": 1,
       "ring": 3,
       "label": "AWS Glue",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://aws.amazon.com/glue/"
     },
     {
       "quadrant": 1,
       "ring": 3,
       "label": "AWS Athena",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://aws.amazon.com/athena/"
     },
     {
       "quadrant": 1,
       "ring": 3,
       "label": "AWS Elastic Kubernetes Service",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://aws.amazon.com/eks/"
     },
     {
       "quadrant": 1,
       "ring": 2,
       "label": "AWS Fargate",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://aws.amazon.com/fargate/"
     },
     {
       "quadrant": 1,
       "ring": 3,
       "label": "Splunk",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.splunk.com/"
     },
     {
       "quadrant": 1,
       "ring": 3,
       "label": "Jenkins",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.jenkins.io/"
     },
     {
       "quadrant": 3,
       "ring": 0,
       "label": "Scrum",
       "active": true,
-      "moved": 0
+      "moved": 0,
+      "link": "https://www.scrum.org/learning-series/what-is-scrum/"
     },
     {
       "quadrant": 3,

--- a/tests/schema/config.schema.json
+++ b/tests/schema/config.schema.json
@@ -62,7 +62,7 @@
           "examples": ["https://www.python.org/", "https://go.dev/"]
         }
       },
-      "required": ["quadrant", "ring", "label", "active", "moved"],
+      "required": ["quadrant", "ring", "label", "active", "moved", "link"],
       "additionalProperties": false
     }
   }


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the configuration and schema files to include a new `link` property for various tools and technologies. This change enhances the metadata by providing direct links to relevant resources. The most important changes are as follows:

### Configuration Updates:
* Added a `link` property to multiple entries in the `github-pages/config.json` file, providing URLs for tools like AWS Kinesis, AWS Glue, AWS Athena, AWS EKS, AWS Fargate, Splunk, Jenkins, and Scrum.

### Schema Updates:
* Updated the schema in `tests/schema/config.schema.json` (renamed from `tests/config.schema.json`) to include `link` as a required property, ensuring all entries in the configuration file now mandate a valid URL.