### PR TITLE
Update Test Dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,16 @@ updates:
         update-types:
           - "patch"
           - "minor"
+
+  - package-ecosystem: "uv"
+    directory: "tests"
+    schedule:
+      interval: "cron"
+      cronjob: "30 7 * * *"
+      timezone: "Europe/London"
+    target-branch: "main"
+    groups:
+      python:
+        applies-to: "version-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new configuration to `.github/dependabot.yml` to enable automated dependency updates for Python packages in the `tests` directory. The updates are scheduled to run daily at 7:30 AM London time and will target the `main` branch.

Dependabot configuration enhancements:

* Added a new `uv` package ecosystem entry for the `tests` directory to automate Python dependency updates.
* Scheduled updates using a daily cron job at 7:30 AM in the Europe/London timezone, targeting the `main` branch.
* Grouped all Python version updates under a single group named `python` using a wildcard pattern.
