### PR TITLE
Improve Website Wording and Add Snapshot Just Commands

### DIFF
--- a/github-pages/index.html
+++ b/github-pages/index.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
     <meta
       name="description"
-      content="Jack Plowman's Tech Radar: a tool to visualize technology understanding to inspire and support tech choices on future projects"
+      content="Jack Plowman's Tech Radar: an interactive visualization of technology expertise and adoption, designed to guide and inspire future project decisions."
     />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Jack Plowman's Tech Radar</title>
@@ -105,7 +105,7 @@
 
             <p>
               Jack Plowman's Tech Radar is a list of technologies, complemented
-              by an assessment result, called <em>ring assignment</em>. We use
+              by an assessment result, called <em>ring assignment</em>. I use
               four rings with the following semantics:
             </p>
 

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -4,14 +4,15 @@ name = "tests"
 dynamic = ["version"]
 requires-python = "~=3.13.0"
 dependencies= [
-  "pytest==8.4.2",
+  "check-jsonschema==0.34.0",
+  "greenlet==3.2.4",
   "playwright==1.55.0",
   "pytest-playwright==0.7.1",
   "pytest-rerunfailures==16.0.1",
+  "pytest==8.4.2",
   "ruff==0.13.2",
-  "vulture==2.14",
   "ty==0.0.1a21",
-  "check-jsonschema==0.34.0",
+  "vulture==2.14",
 ]
 
 [tool.uv]
@@ -40,26 +41,6 @@ ignore = [
 
 fixable = ["ALL"]
 unfixable = []
-
-exclude = [
-  ".bzr",
-  ".direnv",
-  ".eggs",
-  ".git",
-  ".hg",
-  ".mypy_cache",
-  ".nox",
-  ".pants.d",
-  ".pytype",
-  ".ruff_cache",
-  ".svn",
-  ".tox",
-  ".venv",
-  "__pypackages__",
-  "_build",
-]
-
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.ruff.lint.per-file-ignores]
 "**test_*.py" = ["S101", "D102", "D103", "SLF001", "PT019"]

--- a/tests/tests.just
+++ b/tests/tests.just
@@ -24,6 +24,10 @@ run-ci $browser:
 playwright-install:
     uv run playwright install --with-deps
 
+# Generate Snapshot for Visual Regression Testing
+generate-snapshot $PROJECT_URL=DEFAULT_PROJECT_URL $browser="chromium":
+    uv run python ui/generate_snapshot.py --url ${PROJECT_URL} --browser ${browser}
+
 # Remove all compiled Python files
 clean:
     find . \( \
@@ -36,7 +40,8 @@ clean:
       -name '*.pyd' -o \
       -name '*.pyo' -o \
       -name 'coverage.xml' -o \
-      -name 'db.sqlite3' \
+      -name 'db.sqlite3' -o \
+      -name '__snapshots__' \
     \) -print | xargs rm -rfv
 
 # ------------------------------------------------------------------------------

--- a/tests/ui/generate_snapshot.py
+++ b/tests/ui/generate_snapshot.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import os
+from os import getenv
 from pathlib import Path
 
 from playwright.sync_api import sync_playwright
@@ -8,7 +8,7 @@ from playwright.sync_api import sync_playwright
 
 def main() -> None:
     """Generate a snapshot of the tech radar page for visual regression testing."""
-    project_url = os.environ.get("PROJECT_URL")
+    project_url = getenv("PROJECT_URL")
     if not project_url:
         msg = (
             "The environment variable 'PROJECT_URL' "

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -81,19 +81,19 @@ wheels = [
 
 [[package]]
 name = "greenlet"
-version = "3.2.3"
+version = "3.2.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/92/bb85bd6e80148a4d2e0c59f7c0c2891029f8fd510183afc7d8d2feeed9b6/greenlet-3.2.3.tar.gz", hash = "sha256:8b0dd8ae4c0d6f5e54ee55ba935eeb3d735a9b58a8a1e5b5cbab64e01a39f365", size = 185752, upload-time = "2025-06-05T16:16:09.955Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/b8/704d753a5a45507a7aab61f18db9509302ed3d0a27ac7e0359ec2905b1a6/greenlet-3.2.4.tar.gz", hash = "sha256:0dca0d95ff849f9a364385f36ab49f50065d76964944638be9691e1832e9f86d", size = 188260, upload-time = "2025-08-07T13:24:33.51Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/cf/f5c0b23309070ae93de75c90d29300751a5aacefc0a3ed1b1d8edb28f08b/greenlet-3.2.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:500b8689aa9dd1ab26872a34084503aeddefcb438e2e7317b89b11eaea1901ad", size = 270732, upload-time = "2025-06-05T16:10:08.26Z" },
-    { url = "https://files.pythonhosted.org/packages/48/ae/91a957ba60482d3fecf9be49bc3948f341d706b52ddb9d83a70d42abd498/greenlet-3.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a07d3472c2a93117af3b0136f246b2833fdc0b542d4a9799ae5f41c28323faef", size = 639033, upload-time = "2025-06-05T16:38:53.983Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/df/20ffa66dd5a7a7beffa6451bdb7400d66251374ab40b99981478c69a67a8/greenlet-3.2.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:8704b3768d2f51150626962f4b9a9e4a17d2e37c8a8d9867bbd9fa4eb938d3b3", size = 652999, upload-time = "2025-06-05T16:41:37.89Z" },
-    { url = "https://files.pythonhosted.org/packages/51/b4/ebb2c8cb41e521f1d72bf0465f2f9a2fd803f674a88db228887e6847077e/greenlet-3.2.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5035d77a27b7c62db6cf41cf786cfe2242644a7a337a0e155c80960598baab95", size = 647368, upload-time = "2025-06-05T16:48:21.467Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/6a/1e1b5aa10dced4ae876a322155705257748108b7fd2e4fae3f2a091fe81a/greenlet-3.2.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2d8aa5423cd4a396792f6d4580f88bdc6efcb9205891c9d40d20f6e670992efb", size = 650037, upload-time = "2025-06-05T16:13:06.402Z" },
-    { url = "https://files.pythonhosted.org/packages/26/f2/ad51331a157c7015c675702e2d5230c243695c788f8f75feba1af32b3617/greenlet-3.2.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c724620a101f8170065d7dded3f962a2aea7a7dae133a009cada42847e04a7b", size = 608402, upload-time = "2025-06-05T16:12:51.91Z" },
-    { url = "https://files.pythonhosted.org/packages/26/bc/862bd2083e6b3aff23300900a956f4ea9a4059de337f5c8734346b9b34fc/greenlet-3.2.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:873abe55f134c48e1f2a6f53f7d1419192a3d1a4e873bace00499a4e45ea6af0", size = 1119577, upload-time = "2025-06-05T16:36:49.787Z" },
-    { url = "https://files.pythonhosted.org/packages/86/94/1fc0cc068cfde885170e01de40a619b00eaa8f2916bf3541744730ffb4c3/greenlet-3.2.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:024571bbce5f2c1cfff08bf3fbaa43bbc7444f580ae13b0099e95d0e6e67ed36", size = 1147121, upload-time = "2025-06-05T16:12:42.527Z" },
-    { url = "https://files.pythonhosted.org/packages/27/1a/199f9587e8cb08a0658f9c30f3799244307614148ffe8b1e3aa22f324dea/greenlet-3.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:5195fb1e75e592dd04ce79881c8a22becdfa3e6f500e7feb059b1e6fdd54d3e3", size = 297603, upload-time = "2025-06-05T16:20:12.651Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
+    { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/15/0d5e4e1a66fab130d98168fe984c509249c833c1a3c16806b90f253ce7b9/greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae", size = 1149210, upload-time = "2025-08-07T13:18:24.072Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/55/2321e43595e6801e105fcfdee02b34c0f996eb71e6ddffca6b10b7e1d771/greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b", size = 299685, upload-time = "2025-08-07T13:24:38.824Z" },
 ]
 
 [[package]]
@@ -412,6 +412,7 @@ name = "tests"
 source = { virtual = "." }
 dependencies = [
     { name = "check-jsonschema" },
+    { name = "greenlet" },
     { name = "playwright" },
     { name = "pytest" },
     { name = "pytest-playwright" },
@@ -424,6 +425,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "check-jsonschema", specifier = "==0.34.0" },
+    { name = "greenlet", specifier = "==3.2.4" },
     { name = "playwright", specifier = "==1.55.0" },
     { name = "pytest", specifier = "==8.4.2" },
     { name = "pytest-playwright", specifier = "==0.7.1" },


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces improvements to both the documentation and testing infrastructure for the Tech Radar project. The most notable changes include enhancements to the description and explanation in the main web page, updates to the Python test environment dependencies, and new tooling for visual regression testing. These updates help clarify the project's purpose and streamline quality assurance processes.

**Documentation improvements:**

* Updated the meta description in `github-pages/index.html` to better reflect the interactive and guiding nature of the Tech Radar visualization.
* Changed explanatory text under "What is the Tech Radar?" to use first-person language, making it more personal and clear.

**Testing and CI enhancements:**

* Added new dependencies (`check-jsonschema`, `greenlet`) and reordered the list in `tests/pyproject.toml` for improved clarity and compatibility.
* Removed redundant `exclude` and `dummy-variable-rgx` configuration from `tests/pyproject.toml` to simplify linting setup.
* Added a new `generate-snapshot` command to `tests/tests.just` and implemented the corresponding `ui/generate_snapshot.py` script for automated visual regression snapshot generation. [[1]](diffhunk://#diff-83e2fb4528694cfa62c213eefec53e6aeee0353030bf91ad4f830e69854b7918R27-R30) [[2]](diffhunk://#diff-1991d98e5ed6c0bc83682e17ae27fb3db84cbc30f7f528c838c3265965c0fbf3L3-R11)
* Updated the `clean` command in `tests/tests.just` to also remove generated snapshot files, keeping the workspace tidy.
