### PR TITLE
Update Prek Hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         description: Scan for secrets using Gitleaks
         language_version: "go1.25"
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.10
+    rev: v1.7.11
     hooks:
       - id: actionlint
         name: Actionlint


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the version of the `actionlint` pre-commit hook in the `.pre-commit-config.yaml` file.

Tooling update:

* Upgraded the `actionlint` repository from version `v1.7.10` to `v1.7.11` in `.pre-commit-config.yaml`, ensuring the latest improvements and bug fixes are used for GitHub Actions linting.
