### PR TITLE
Fix Security Warnings

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -130,7 +130,7 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # zizmor: ignore[secrets-outside-env]
 
   schema-validation:
     name: Schema Validation

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
   "playwright==1.58.0",
   "pytest-playwright==0.7.2",
   "pytest-rerunfailures==16.1",
-  "pytest==9.0.2",
+  "pytest==9.0.3",
   "ruff==0.15.9",
   "ty==0.0.29",
   "vulture==2.16",

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -231,7 +231,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -240,9 +240,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -450,7 +450,7 @@ dependencies = [
 requires-dist = [
     { name = "check-jsonschema", specifier = "==0.37.1" },
     { name = "playwright", specifier = "==1.58.0" },
-    { name = "pytest", specifier = "==9.0.2" },
+    { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-playwright", specifier = "==0.7.2" },
     { name = "pytest-rerunfailures", specifier = "==16.1" },
     { name = "ruff", specifier = "==0.15.9" },


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the testing dependencies and a small change to the GitHub Actions workflow configuration. The main changes are:

Dependency update:

* Upgraded the `pytest` dependency from version 9.0.2 to 9.0.3 in `tests/pyproject.toml` to ensure the latest bug fixes and improvements are included.

Workflow configuration:

* Added a `zizmor: ignore[secrets-outside-env]` comment to the `SONAR_TOKEN` environment variable in `.github/workflows/code-checks.yml` to suppress a specific linter warning about secrets usage.
