### PR TITLE
Update Prek Freeze Command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # Pre-commit configuration for use with `prek` (https://github.com/j178/prek)
 
-minimum_prek_version: "0.3.0"
+minimum_prek_version: "0.4.0"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/Justfile
+++ b/Justfile
@@ -101,7 +101,7 @@ prek-update:
 
 # Prek update hooks
 prek-update-hooks:
-    prek autoupdate
+    prek update --freeze
 
 prek-update-additional-dependencies:
     uv run --script https://raw.githubusercontent.com/JackPlowman/update-prek-additional-dependencies/refs/heads/main/update_prek_additional_dependencies.py
@@ -114,4 +114,3 @@ prek-update-additional-dependencies:
 update:
     just pinact-update
     just prek-update
-    just prek-update-additional-dependencies


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the project's pre-commit tooling and related automation to align with newer versions and streamline update processes. The main changes focus on updating the minimum required version of `prek`, adjusting how hooks are updated, and simplifying the update workflow.

**Pre-commit tooling updates:**

* Updated the `minimum_prek_version` from `"0.3.0"` to `"0.4.0"` in `.pre-commit-config.yaml` to require a newer version of the `prek` tool.
* Changed the `prek-update-hooks` command in the `Justfile` to use `prek update --freeze` instead of `prek autoupdate`, ensuring updates are frozen for reproducibility.

**Workflow simplification:**

* Removed the `prek-update-additional-dependencies` step from the `update` recipe in the `Justfile`, streamlining the update process.